### PR TITLE
docs: add and improve JavaDoc across project classes

### DIFF
--- a/main/CadastroAlunos.java
+++ b/main/CadastroAlunos.java
@@ -30,18 +30,45 @@ public class CadastroAlunos {
         this.arm = arm;
     }
 
+    /**
+     * Insere um novo aluno no cadastro, delegando ao armazenador subjacente.
+     *
+     * @param a O aluno a ser inserido.
+     * @throws RaDuplicadoException   se ja existir um aluno com o mesmo RA.
+     * @throws CadastroCheioException se a estrutura ja estiver na capacidade maxima.
+     */
     public void inserir(Aluno a) throws RaDuplicadoException, CadastroCheioException {
         arm.inserir(a);
     }
 
+    /**
+     * Remove do cadastro o aluno cujo RA foi informado.
+     *
+     * @param ra RA do aluno a ser removido.
+     * @throws RaInexistenteException se nao existir aluno com o RA informado.
+     */
     public void remover(String ra) throws RaInexistenteException {
         arm.remover(ra);
     }
 
+    /**
+     * Atualiza os dados do aluno identificado pelo RA, substituindo seu
+     * registro pelo novo aluno fornecido.
+     *
+     * @param ra        RA do aluno a ser atualizado.
+     * @param novoAluno Novo objeto Aluno que substituira o registro atual.
+     * @throws RaInexistenteException se nao existir aluno com o RA informado.
+     */
     public void atualizar(String ra, Aluno novoAluno) throws RaInexistenteException {
         arm.atualizar(ra, novoAluno);
     }
 
+    /**
+     * Verifica se existe um aluno cadastrado com o RA informado.
+     *
+     * @param ra RA a ser consultado.
+     * @return {@code true} se o aluno existir no cadastro, {@code false} caso contrario.
+     */
     public boolean existe(String ra) {
         return arm.existe(ra);
     }
@@ -56,6 +83,15 @@ public class CadastroAlunos {
         return arm.buscar(ra);
     }
 
+    /**
+     * Gera uma listagem textual de todos os alunos cadastrados.
+     *
+     * @param formatoBibliografico Se {@code true}, os nomes sao exibidos no
+     *                             formato bibliografico (ex.: SILVA, J. M.);
+     *                             se {@code false}, no formato comum.
+     * @return String contendo a lista formatada, ou mensagem indicando
+     *         cadastro vazio quando nao houver alunos.
+     */
     public String listar(boolean formatoBibliografico) {
         return arm.listar(formatoBibliografico);
     }

--- a/storage/GravarArray.java
+++ b/storage/GravarArray.java
@@ -2,12 +2,22 @@ package storage;
 
 import java.io.*;
 /**
- * Escreva uma descrição da classe GravarArray aqui.
- * 
- * @author (seu nome) 
- * @version (um número da versão ou uma data)
+ * Exemplo de gravacao e leitura de um array de {@link model.Pessoa} em
+ * arquivo binario utilizando a classe utilitaria {@link ArquivoBinario}.
+ * Demonstra como persistir multiplos objetos serializaveis de uma unica vez
+ * e recupera-los preservando o tipo do array original.
+ *
+ * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward
+ * @version 1.0 2026/04/27
  */
 public class GravarArray {
+    /**
+     * Ponto de entrada do exemplo: cria um array de pessoas, grava-o em
+     * arquivo binario e em seguida le o conteudo de volta para a memoria,
+     * imprimindo os objetos lidos.
+     *
+     * @param args Argumentos de linha de comando (nao utilizados).
+     */
     public static void main(String[] args) {
         /*
         Pessoa cad[] = new Pessoa[2];

--- a/test/TestaAluno.java
+++ b/test/TestaAluno.java
@@ -1,14 +1,24 @@
-/**
- * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward 
- * @version 19/03/2026
- */
 package test;
 
 import model.Aluno;
 import model.IdadeInvalidaException;
 import model.SemestreInvalidoException;
 
+/**
+ * Teste manual da classe {@link Aluno}: constroi um aluno com dados validos,
+ * imprime sua representacao textual padrao e o nome em formato bibliografico,
+ * tratando as excecoes de validacao de idade e semestre.
+ *
+ * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward
+ * @version 1.0 2026/03/19
+ */
 public class TestaAluno {
+    /**
+     * Ponto de entrada do teste manual. Cria uma instancia de {@link Aluno}
+     * e imprime no console seu {@code toString()} e seu nome bibliografico.
+     *
+     * @param args Argumentos de linha de comando (nao utilizados).
+     */
     public static void main(String args[]) {
         try {
             Aluno a = new Aluno("Ze da Silva Pereira Antunes", 22, "RA123456", "Engenharia Civil", 3);

--- a/test/TestaCadastro.java
+++ b/test/TestaCadastro.java
@@ -25,9 +25,19 @@ import storage.CadastroCheioException;
  */
 public class TestaCadastro {
 
+    /** Contador de asserções que passaram durante a execução das baterias. */
     private static int passou = 0;
+    /** Contador de asserções que falharam durante a execução das baterias. */
     private static int falhou = 0;
 
+    /**
+     * Registra o resultado de uma asserção, atualizando os contadores
+     * {@link #passou} ou {@link #falhou} e imprimindo o desfecho no console.
+     *
+     * @param nome     Descricao curta do caso de teste sendo verificado.
+     * @param condicao Resultado da asserção: {@code true} para sucesso,
+     *                 {@code false} para falha.
+     */
     private static void verificar(String nome, boolean condicao) {
         if (condicao) {
             passou++;
@@ -38,6 +48,14 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Fabrica um {@link Aluno} valido pronto para uso nos testes, evitando
+     * repeticao dos blocos try/catch em cada caso. Usa dados ficticios e
+     * apenas varia o RA fornecido.
+     *
+     * @param ra RA a ser atribuido ao aluno de teste.
+     * @return Aluno valido com nome, idade, curso e semestre padrao.
+     */
     private static Aluno criar(String ra) {
         try {
             return new Aluno("Fulano de Tal", 25, ra, "Computacao", 3);
@@ -56,6 +74,12 @@ public class TestaCadastro {
         CadastroAlunos novo(int qtde);
     }
 
+    /**
+     * Verifica que a insercao de um aluno valido grava o registro no
+     * cadastro (consulta {@link CadastroAlunos#existe(String)} apos inserir).
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testInserirOk(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -66,6 +90,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que inserir um aluno com RA ja existente lanca
+     * {@link RaDuplicadoException}.
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testInserirDuplicado(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -79,6 +109,13 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que inserir alem da capacidade de uma estrutura de tamanho
+     * fixo (vetor) lanca {@link CadastroCheioException}. Aplicavel apenas
+     * ao {@link Armazenador} (a lista e elastica).
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testCadastroCheio(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(2);
         try {
@@ -93,6 +130,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que a remocao de um aluno existente retira efetivamente o
+     * registro do cadastro.
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testRemoverOk(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -104,6 +147,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que tentar remover um RA inexistente lanca
+     * {@link RaInexistenteException}.
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testRemoverInexistente(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -114,6 +163,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que a atualizacao de um aluno existente substitui os dados
+     * antigos pelos novos (confirmado via {@link CadastroAlunos#listar(boolean)}).
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testAtualizarOk(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -127,6 +182,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que tentar atualizar um RA inexistente lanca
+     * {@link RaInexistenteException}.
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testAtualizarInexistente(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -139,6 +200,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que valores de idade fora do intervalo permitido
+     * ({@link Aluno#IDADE_MIN} a {@link Aluno#IDADE_MAX}) provocam
+     * {@link IdadeInvalidaException} na construcao do aluno. Testa tanto
+     * idade negativa quanto idade acima do limite superior.
+     */
     private static void testIdadeInvalida() {
         try {
             new Aluno("Negativo", -1, "RA1", "Curso", 1);
@@ -159,6 +226,11 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica que valores de semestre fora do intervalo permitido
+     * ({@link Aluno#SEMESTRE_MIN} a {@link Aluno#SEMESTRE_MAX}) provocam
+     * {@link SemestreInvalidoException} na construcao do aluno.
+     */
     private static void testSemestreInvalido() {
         try {
             new Aluno("Fulano", 20, "RA1", "Curso", 0);
@@ -179,6 +251,12 @@ public class TestaCadastro {
         }
     }
 
+    /**
+     * Verifica a listagem do cadastro nos dois formatos (comum e
+     * bibliografico) e tambem a mensagem retornada para um cadastro vazio.
+     *
+     * @param fab Fabrica de cadastros usada para criar a instancia sob teste.
+     */
     private static void testListar(FabricaCadastro fab) {
         CadastroAlunos ca = fab.novo(3);
         try {
@@ -218,6 +296,15 @@ public class TestaCadastro {
         testListar(fab);
     }
 
+    /**
+     * Ponto de entrada dos testes manuais. Executa primeiro a validacao do
+     * modelo (idade e semestre) e em seguida roda a bateria completa contra
+     * as duas implementacoes de {@link IArmazenador}: {@link Armazenador}
+     * (vetor) e {@link ArmazenadorLista} (lista ligada). Ao final, imprime
+     * o total de asserções que passaram e falharam.
+     *
+     * @param args Argumentos de linha de comando (nao utilizados).
+     */
     public static void main(String[] args) {
         System.out.println("=== TestaCadastro ===");
 

--- a/test/TestaNomePessoa.java
+++ b/test/TestaNomePessoa.java
@@ -1,13 +1,23 @@
-/**
- * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward 
- * @version 19/03/2026
- */
 package test;
 
 import model.NomePessoa;
 import javax.swing.JOptionPane;
 
+/**
+ * Teste manual da classe {@link NomePessoa}: solicita um nome ao usuario
+ * via {@link JOptionPane} e imprime no console o nome original (com
+ * quantidade de palavras), sua versao invertida e o formato bibliografico.
+ *
+ * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward
+ * @version 1.0 2026/03/19
+ */
 public class TestaNomePessoa {
+    /**
+     * Ponto de entrada do teste manual. Le um nome digitado pelo usuario e
+     * exibe no console as variacoes geradas por {@link NomePessoa}.
+     *
+     * @param args Argumentos de linha de comando (nao utilizados).
+     */
     public static void main(String[] args) {
         String nomePessoa = JOptionPane.showInputDialog("Forneça um nome: ");
 

--- a/test/TestaTexto.java
+++ b/test/TestaTexto.java
@@ -1,14 +1,23 @@
-/**
- * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward 
- * @version 17/03/2026
- */
 package test;
 
 import model.Texto;
 import javax.swing.JOptionPane;
 
-
+/**
+ * Teste manual da classe {@link Texto}: solicita um texto ao usuario via
+ * {@link JOptionPane} e imprime no console o texto original (com a
+ * quantidade de palavras) e sua versao invertida.
+ *
+ * @author Kaua Bezerra, Liam Vedovato, Raul Kolaric, Rodrigo Ward
+ * @version 1.0 2026/03/17
+ */
 public class TestaTexto {
+    /**
+     * Ponto de entrada do teste manual. Le um texto digitado pelo usuario e
+     * exibe no console suas variacoes geradas por {@link Texto}.
+     *
+     * @param args Argumentos de linha de comando (nao utilizados).
+     */
     public static void main(String[] args) {
         String texto = JOptionPane.showInputDialog("Forneça um texto: ");
 


### PR DESCRIPTION
- main/CadastroAlunos: add JavaDoc to inserir, remover, atualizar, existe and listar (the facade methods were the only ones missing documentation)
- storage/GravarArray: replace BlueJ placeholder JavaDoc with a real class description, correct authors and document main
- test/TestaCadastro: document passou/falhou counters, verificar, criar fabric, all 10 test methods (testInserirOk, testInserirDuplicado, testCadastroCheio, testRemoverOk, testRemoverInexistente, testAtualizarOk, testAtualizarInexistente, testIdadeInvalida, testSemestreInvalido, testListar) and main
- test/TestaAluno, test/TestaNomePessoa, test/TestaTexto: move misplaced JavaDoc from above the package declaration to above the class, add proper class description, standardize @version format and document main
- follow the existing project convention: Brazilian Portuguese without diacritics, JavaDoc tags @param/@return/@throws, {@link} and {@code} references